### PR TITLE
release: v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "n2p"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,9 +1868,11 @@ dependencies = [
  "clap",
  "iroh",
  "iroh-base",
+ "rand 0.8.5",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "xdg",
 ]
 
 [[package]]
@@ -4246,6 +4248,12 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "n2p"
 description = "Share your daemons with your peers"
 homepage = "https://github.com/ysndr/n2p"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ tokio = "1"
 anyhow = "1"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+rand = "0.8"
+xdg = "3.0.0"

--- a/README.md
+++ b/README.md
@@ -9,15 +9,31 @@ or excessive setup.
 
 ## USAGE
 
-### `n2p server`
+### `n2p server [OPTIONS]`
 
 Starts a local node that forwards connections to the local nix daemon socket.
 Logs "short" and "long" addresses to stderr, that can be used to connect a client.
 
-### `n2p client <address>`
+#### Options:
+
+      --secret-key-file <SECRET_KEY_FILE>
+          secret key identifying this node if omitted will create a random token and store it in XDG_STATE_DIR/n2p
+      --one-time-key
+          run the server with a non persistent address
+      --timeout <TIMEOUT>
+          shutdown after <TIMEOUT> seconds of no connection
+
+### `n2p client [OPTIONS] <SERVER_ADDRESS>`
 
 Sets up a local unix socket that can be used by nix in the url position of arguments
 that take store urls (e.g. `nix copy --to <url>`).
+
+#### Arguments:
+
+    <SERVER_ADDRESS>  address of the server node printed on startup
+
+#### Options:
+      --timeout <TIMEOUT>  shutdown after <TIMEOUT> seconds of no connection
 
 #### Example
 

--- a/src/bin/n2p.rs
+++ b/src/bin/n2p.rs
@@ -1,10 +1,11 @@
-use std::{fmt::Debug, str::FromStr};
+use std::{fmt::Debug, path::PathBuf, str::FromStr};
 
 use anyhow::{Context, Result};
 use clap::Parser;
 
 use n2p::{
     client::{Client, NodeTicket, proxy_incoming_stream_to_remote, start_listener},
+    key::{generate_secret_key, read_key_from_file, read_user_key, write_user_key},
     server::{Server, proxy_incoming_stream_to_nix_daemon},
 };
 use tokio::select;
@@ -20,8 +21,21 @@ struct Args {
 
 #[derive(Debug, Clone, clap::Subcommand)]
 enum Mode {
-    Server,
-    Client { server_address: NodeTicket },
+    /// Run a server node that receives requests and forwards them to the local nix daemon
+    Server {
+        /// secret key identifying this node
+        /// if omitted will create a random token and store it in XDG_STATE_DIR/n2p
+        #[clap(long)]
+        secret_key_file: Option<PathBuf>,
+        /// run the server with a non persistent address
+        #[clap(long)]
+        one_time_key: bool,
+    },
+    /// Run a client node accepts nix daemon connections and forwards them to <SERVER_ADDRESS>
+    Client {
+        /// address of the server node printed on startup
+        server_address: NodeTicket,
+    },
 }
 
 #[tokio::main]
@@ -47,14 +61,33 @@ async fn main() -> Result<()> {
 
 async fn run(args: Args) -> Result<()> {
     match args.mode {
-        Mode::Server => server().await?,
+        Mode::Server {
+            secret_key_file,
+            one_time_key,
+        } => server(secret_key_file, one_time_key).await?,
         Mode::Client { server_address } => client(server_address).await?,
     }
     Ok(())
 }
 
-async fn server() -> Result<()> {
-    let p2p_server = Server::new().await.context("could not create p2p server")?;
+async fn server(secret_key_file: Option<PathBuf>, one_time_key: bool) -> Result<()> {
+    let secret_key = {
+        if let Some(secret_key_file) = secret_key_file {
+            read_key_from_file(&secret_key_file).await?
+        } else if let Some(secret_key) = read_user_key().await? {
+            secret_key
+        } else {
+            let secret_key = generate_secret_key();
+            if !one_time_key {
+                write_user_key(&secret_key).await?;
+            }
+            secret_key
+        }
+    };
+
+    let p2p_server = Server::new(secret_key)
+        .await
+        .context("could not create p2p server")?;
 
     let address = p2p_server.address().await?;
     let short_address = p2p_server.short_address().await?;

--- a/src/bin/n2p.rs
+++ b/src/bin/n2p.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, path::PathBuf, str::FromStr};
+use std::{fmt::Debug, path::PathBuf, str::FromStr, time::Duration};
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -8,8 +8,8 @@ use n2p::{
     key::{generate_secret_key, read_key_from_file, read_user_key, write_user_key},
     server::{Server, proxy_incoming_stream_to_nix_daemon},
 };
-use tokio::select;
-use tracing::info;
+use tokio::{select, time::error::Elapsed};
+use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, clap::Parser)]
@@ -30,9 +30,15 @@ enum Mode {
         /// run the server with a non persistent address
         #[clap(long)]
         one_time_key: bool,
+        /// shutdown after <TIMEOUT> seconds of no connection
+        #[clap(long)]
+        timeout: Option<u32>,
     },
     /// Run a client node accepts nix daemon connections and forwards them to <SERVER_ADDRESS>
     Client {
+        /// shutdown after <TIMEOUT> seconds of no connection
+        #[clap(long)]
+        timeout: Option<u32>,
         /// address of the server node printed on startup
         server_address: NodeTicket,
     },
@@ -64,13 +70,21 @@ async fn run(args: Args) -> Result<()> {
         Mode::Server {
             secret_key_file,
             one_time_key,
-        } => server(secret_key_file, one_time_key).await?,
-        Mode::Client { server_address } => client(server_address).await?,
+            timeout,
+        } => server(secret_key_file, one_time_key, timeout).await?,
+        Mode::Client {
+            server_address,
+            timeout,
+        } => client(server_address, timeout).await?,
     }
     Ok(())
 }
 
-async fn server(secret_key_file: Option<PathBuf>, one_time_key: bool) -> Result<()> {
+async fn server(
+    secret_key_file: Option<PathBuf>,
+    one_time_key: bool,
+    timeout: Option<u32>,
+) -> Result<()> {
     let secret_key = {
         if let Some(secret_key_file) = secret_key_file {
             read_key_from_file(&secret_key_file).await?
@@ -95,20 +109,57 @@ async fn server(secret_key_file: Option<PathBuf>, one_time_key: bool) -> Result<
     info!(%address, %short_address, "server started");
 
     loop {
-        let stream = p2p_server.accept_connection().await?;
+        let stream = with_timeout(timeout, p2p_server.accept_connection()).await;
+        let stream = match stream {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(err)) => {
+                error!(%err, "failed accepting request");
+                continue;
+            }
+            Err(_elapsed) => {
+                info!("timeout reached, shutting down");
+                return Ok(());
+            }
+        };
+
         let _ = proxy_incoming_stream_to_nix_daemon(stream).await;
     }
 }
 
-async fn client(server_address: NodeTicket) -> Result<()> {
+async fn client(server_address: NodeTicket, timeout: Option<u32>) -> Result<()> {
     let (socket_file_guard, listener) = start_listener(&server_address)?;
     let p2p_client = Client::new().await?;
 
     println!("{}", socket_file_guard.as_nix_store_url());
 
     loop {
-        let (local_stream, _) = listener.accept().await?;
+        let timeout_result = with_timeout(timeout, async {
+            let (local_stream, _) = listener.accept().await?;
+            anyhow::Ok(local_stream)
+        })
+        .await;
+
+        let local_stream = match timeout_result {
+            Ok(Ok(local_stream)) => local_stream,
+            Ok(Err(err)) => {
+                error!(%err, "failed accepting request");
+                continue;
+            }
+            Err(_elapsed) => {
+                info!("timeout reached, shutting down");
+                return Ok(());
+            }
+        };
+
         let _ = proxy_incoming_stream_to_remote(local_stream, &p2p_client, server_address.clone())
             .await;
     }
+}
+
+async fn with_timeout<F: IntoFuture>(timeout: Option<u32>, fut: F) -> Result<F::Output, Elapsed> {
+    if let Some(duration) = timeout {
+        let duration = Duration::from_secs(duration.into());
+        return tokio::time::timeout(duration, fut).await;
+    }
+    Ok(fut.await)
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,0 +1,61 @@
+use std::{path::Path, sync::LazyLock};
+
+use anyhow::{Context, Result, anyhow};
+use iroh::SecretKey;
+use tokio::{
+    fs::{self, File},
+    io::AsyncWriteExt,
+};
+
+use tracing::info;
+use xdg::BaseDirectories;
+
+static DIRS: LazyLock<BaseDirectories> = LazyLock::new(|| BaseDirectories::with_prefix("n2p"));
+
+pub fn generate_secret_key() -> SecretKey {
+    SecretKey::generate(&mut rand::rngs::OsRng)
+}
+
+pub async fn read_key_from_file(path: impl AsRef<Path>) -> Result<SecretKey> {
+    let key_bytes = fs::read(&path)
+        .await
+        .with_context(|| format!("could not read key file {}", path.as_ref().display()))?;
+
+    let data = <[u8; 32]>::try_from(key_bytes).map_err(|bytes| {
+        anyhow!(
+            "key file has unexpected size of {}, expected 32",
+            bytes.len(),
+        )
+    })?;
+
+    let key = SecretKey::from_bytes(&data);
+    Ok(key)
+}
+
+pub async fn read_user_key() -> Result<Option<SecretKey>> {
+    let Some(key_file) = DIRS.find_state_file("secret.key") else {
+        return Ok(None);
+    };
+
+    Some(read_key_from_file(key_file).await).transpose()
+}
+
+pub async fn write_user_key(key: &SecretKey) -> Result<()> {
+    let key_file = DIRS
+        .place_state_file("secret.key")
+        .context("could not prepare state dir")?;
+
+    info!(?key_file, "writing secret key to default dir");
+
+    let mut file = File::options()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .mode(0o600)
+        .open(&key_file)
+        .await
+        .context("could not open key file")?;
+
+    file.write_all(&key.to_bytes()).await?;
+    Ok(())
+}

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, sync::LazyLock};
+use std::path::Path;
 
 use anyhow::{Context, Result, anyhow};
 use iroh::SecretKey;
@@ -8,9 +8,8 @@ use tokio::{
 };
 
 use tracing::info;
-use xdg::BaseDirectories;
 
-static DIRS: LazyLock<BaseDirectories> = LazyLock::new(|| BaseDirectories::with_prefix("n2p"));
+use crate::DIRS;
 
 pub fn generate_secret_key() -> SecretKey {
     SecretKey::generate(&mut rand::rngs::OsRng)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod client;
+pub mod key;
 pub mod server;
-
 pub use iroh;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
 pub mod client;
 pub mod key;
 pub mod server;
+
+use std::sync::LazyLock;
+
 pub use iroh;
+use xdg::BaseDirectories;
+
+static DIRS: LazyLock<BaseDirectories> = LazyLock::new(|| BaseDirectories::with_prefix("n2p"));

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,14 +10,11 @@ pub struct Server {
 
 impl Server {
     #[tracing::instrument]
-    pub async fn new() -> Result<Self> {
+    pub async fn new(secret_key: SecretKey) -> Result<Self> {
         let endpoint = Endpoint::builder()
             .alpns(["nix-daemon".into()].to_vec())
             .relay_mode(iroh::RelayMode::Default)
-            .secret_key(SecretKey::from_bytes(&[
-                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                1, 1, 1, 1,
-            ]))
+            .secret_key(secret_key)
             .bind()
             .await?;
         endpoint.home_relay().initialized().await?;


### PR DESCRIPTION
* Add timeouts for server and client to shutdown after provided idle time
* Dynamically generate a local secret key and save it in `XDG_STATE_DIR/n2p` (skip saving the key with `n2p server --one-time-key`)
* Allow specifying secret key files with `n2p server --secret-key-file <FILE>`
* Create client sockets in tempdir, to avoid conflicts and cluttering CWD.